### PR TITLE
ci(CO-204): add jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,32 @@
+import java.text.SimpleDateFormat
+
+pipeline {
+  options {
+    buildDiscarder logRotator(numToKeepStr: '25')
+    disableConcurrentBuilds()
+    office365ConnectorWebhooks(
+      [
+        [name: 'CEP Jenkins', notifyAborted: true, notifyFailure: true, notifySuccess: true, startNotification: true, url: 'https://outlook.office.com/webhook/6bd8ddb7-5c21-46b2-9607-abb31616a113@9d2a793f-db8c-4949-820c-34e31d66b3cd/JenkinsCI/9806314772e748bea62da02351aef4c4/a2049f0f-f62c-4c7a-a04d-cda3616f0217']
+      ]
+    )
+  }
+  agent {
+    kubernetes {
+      cloud "kaniko"
+      label "eslint-config-enspire"
+      serviceAccount "kaniko"
+      yamlFile "KubernetesPod.yaml"
+    }      
+  }
+   stages {
+    stage('publish') {
+      steps {
+        container(name: 'nodejs') {
+          //shared library functions
+          ciPrettyBuildNumber()
+          npmPublish()
+        }
+      }
+    }
+  }
+}

--- a/KubernetesPod.yaml
+++ b/KubernetesPod.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nodejs
+spec:
+  containers:
+  - name: nodejs
+    image: node:8
+    imagePullPolicy: Always
+    command: [ "tail", "-f", "/dev/null" ]
+    tty: true
+    volumeMounts:
+      - name: ssh-volume
+        mountPath: /root/.ssh
+      - name: npm-secret
+        mountPath: /root/.npmrc
+        subPath: .npmrc
+  volumes:
+    - name: ssh-volume
+      secret:
+        secretName: ssh-config
+        defaultMode: 256
+    - name: npm-secret
+      secret:
+        secretName: npm-secret


### PR DESCRIPTION
This is the same configuration that I setup for node-cep-services, node-pim-configuration, and node-pos-configuration to use Jenkins to automatically build and publish the npm package when a tag is created.