### PR TITLE
feat(Arrow Functions): Space before and after an arrow function

### DIFF
--- a/configs/common.js
+++ b/configs/common.js
@@ -49,6 +49,7 @@ module.exports = {
                 allowKeywords: true
             }
         ],
+        'arrow-spacing': 'error',
         eqeqeq: 'error',
         'no-extend-native': 'error',
         'no-alert': 'error',


### PR DESCRIPTION
Adding this rule to prevent lint errors like this one:
https://github.com/envistaInteractive/node-cep-services/pull/547/files#diff-5c5584e92294e41aa883ec11347eee5bd25bea7b26122c1bc90818b84c4096ffR14476

